### PR TITLE
Update RadioButtonGroup to allow setting an `initialValue`

### DIFF
--- a/example/src/Form.js
+++ b/example/src/Form.js
@@ -126,5 +126,9 @@ class Form extends Component {
 
 export default reduxForm({
   form: 'example',
+  initialValues: {
+    delivery: 'delivery',
+    name: 'Jane Doe'
+  },
   validate
 })(Form)

--- a/src/RadioButtonGroup.js
+++ b/src/RadioButtonGroup.js
@@ -2,4 +2,8 @@ import { RadioButtonGroup } from 'material-ui/RadioButton'
 import createComponent from './createComponent'
 import mapError from './mapError'
 
-export default createComponent(RadioButtonGroup, mapError)
+const mapValueToValueSelected = ({ input: { ...inputProps }, ...props }, errorProp) => {
+  return mapError({ ...props, input: { ...inputProps, valueSelected: inputProps.value } }, errorProp)
+}
+
+export default createComponent(RadioButtonGroup, mapValueToValueSelected)

--- a/src/__tests__/RadioButtonGroup.spec.js
+++ b/src/__tests__/RadioButtonGroup.spec.js
@@ -22,7 +22,7 @@ describe('RadioButtonGroup', () => {
         value: 'Foo'
       }
     }).render())
-      .toEqualJSX(<RadioButtonGroup name="myRadio" value="Foo" ref="component"/>)
+      .toEqualJSX(<RadioButtonGroup name="myRadio" value="Foo" valueSelected="Foo" ref="component"/>)
   })
 
   it('renders a RadioButtonGroup with no error when not touched', () => {
@@ -35,7 +35,7 @@ describe('RadioButtonGroup', () => {
         error: 'FooError'
       }
     }).render())
-      .toEqualJSX(<RadioButtonGroup name="myRadio" value="Foo" ref="component"/>)
+      .toEqualJSX(<RadioButtonGroup name="myRadio" value="Foo" valueSelected="Foo" ref="component"/>)
   })
 
   it('renders a RadioButtonGroup with an error', () => {
@@ -49,7 +49,7 @@ describe('RadioButtonGroup', () => {
         touched: true
       }
     }).render())
-      .toEqualJSX(<RadioButtonGroup name="myRadio" value="Foo" errorText="FooError"
+      .toEqualJSX(<RadioButtonGroup name="myRadio" value="Foo" valueSelected="Foo" errorText="FooError"
         ref="component"/>)
   })
 


### PR DESCRIPTION
Hi Erik,

First thank you for both `redux-form` and this wrapper library.  I'm currently implementing a complex form that I need to know if it is "pristine" or not, and these libraries have been a huge time saver for me!

While working on this, I noticed that the `initialValues` were not getting set for `RadioButtonGroup`.

It turns out that this is because [`RadioButtonGroup`](http://www.material-ui.com/#/components/radio-button#radiobuttongroup-properties) expects the selected value to be passed in as `valueSelected`, not `value`.

This pull-request maps that value.

I tried to match your coding style as close as possible, but please leave me feedback, and I'll gladly make any changes you wish.

Thanks in advance!
-Matt