### PR TITLE
Added Picker Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ import {
   RadioButtonGroup,
   SelectField,
   TextField,
-  Toggle
+  Toggle,
+  DatePicker
 } from 'redux-form-material-ui'
 
 class MyForm extends Component {
@@ -64,6 +65,8 @@ class MyForm extends Component {
         </Field>
 
         <Field name="agreeToTerms" component={Checkbox} label="Agree to terms?"/>
+        
+        <Field name="eventDate" component={DatePicker} format={null} hintText="What day is the event?"/>
 
         <Field name="receiveEmails" component={Toggle} label="Please spam me!"/>
 


### PR DESCRIPTION
Had to do a little searching to fix the string type error on picker fields, so it would be helpful to document a picker with format={null} in your main example and avoid errors out of the box.