### PR TITLE
issue_102: defaultToggle now set correctly.

### DIFF
--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -6,15 +6,15 @@ export default createComponent(
   ({
     input: {
       onChange,
-      value,
       ...inputProps
     },
+    defaultToggled,
     meta, // eslint-disable-line no-unused-vars
     ...props
   }) => ({
     ...inputProps,
     ...props,
-    toggled: value ? true : false,
+    toggled: defaultToggled ? true : false,
     onToggle: onChange
   })
 )

--- a/src/__tests__/Toggle.spec.js
+++ b/src/__tests__/Toggle.spec.js
@@ -20,9 +20,9 @@ describe('Toggle', () => {
     expect(new ReduxFormMaterialUIToggle({
       input: {
         name: 'myToggle',
-        onChange: noop,
-        value: false
-      }
+        onChange: noop
+      },
+      defaultToggled: false
     }).render())
       .toEqualJSX(<Toggle name="myToggle" onToggle={noop} ref="component"/>)
   })
@@ -31,9 +31,9 @@ describe('Toggle', () => {
     expect(new ReduxFormMaterialUIToggle({
       input: {
         name: 'myToggle',
-        onChange: noop,
-        value: true
-      }
+        onChange: noop
+      },
+      defaultToggled: true
     }).render())
       .toEqualJSX(<Toggle name="myToggle" toggled onToggle={noop} ref="component"/>)
   })


### PR DESCRIPTION
This is a solutions to [issue 102](https://github.com/erikras/redux-form-material-ui/issues/102) where defaultToggled was not being set.

I think this may be in relation to material-ui version `0.17.0` but i have not done test with prior version. 