### PR TITLE
onChange should be called when user types

### DIFF
--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -13,5 +13,8 @@ export default createComponent(
       if(onNewRequestFunc && typeof onNewRequestFunc === 'function') {
         onNewRequestFunc(value)
       }
-    }
+    },
+    onUpdateInput: value => {
+      inputProps.onChange(value)
+    }}
   }))

--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -16,5 +16,5 @@ export default createComponent(
     },
     onUpdateInput: value => {
       inputProps.onChange(value)
-    }}
+    }
   }))


### PR DESCRIPTION
we need to be able to hook in to the user type event for async autocompletes. we can still listen for selections using "onNewRequest"