### PR TITLE
fix(defaultToggled): Corrected the behavior for the defaultToggled option

### DIFF
--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -8,13 +8,11 @@ export default createComponent(
       onChange,
       ...inputProps
     },
-    defaultToggled,
     meta, // eslint-disable-line no-unused-vars
     ...props
   }) => ({
     ...inputProps,
     ...props,
-    toggled: defaultToggled ? true : false,
     onToggle: onChange
   })
 )

--- a/src/__tests__/Toggle.spec.js
+++ b/src/__tests__/Toggle.spec.js
@@ -24,7 +24,7 @@ describe('Toggle', () => {
       },
       defaultToggled: false
     }).render())
-      .toEqualJSX(<Toggle name="myToggle" onToggle={noop} ref="component"/>)
+      .toEqualJSX(<Toggle name="myToggle" onToggle={noop} ref="component" defaultToggled={false} />)
   })
 
   it('renders a toggled Toggle', () => {
@@ -35,7 +35,18 @@ describe('Toggle', () => {
       },
       defaultToggled: true
     }).render())
-      .toEqualJSX(<Toggle name="myToggle" toggled onToggle={noop} ref="component"/>)
+      .toEqualJSX(<Toggle name="myToggle" onToggle={noop} ref="component" defaultToggled={true} />)
+  })
+
+  it('renders a controlled Toggle', () => {
+    expect(new ReduxFormMaterialUIToggle({
+      input: {
+        name: 'myToggle',
+        onChange: noop,
+      },
+      toggled: true
+    }).render())
+      .toEqualJSX(<Toggle name="myToggle" onToggle={noop} ref="component" toggled={true} />)
   })
 
   it('provides getRenderedComponent', () => {

--- a/src/__tests__/Toggle.spec.js
+++ b/src/__tests__/Toggle.spec.js
@@ -42,7 +42,7 @@ describe('Toggle', () => {
     expect(new ReduxFormMaterialUIToggle({
       input: {
         name: 'myToggle',
-        onChange: noop,
+        onChange: noop
       },
       toggled: true
     }).render())


### PR DESCRIPTION
This should fix #124 

I did not add any warnings or errors are I believe that should be done by material-ui itself.  We just pass through the props.

