### PR TITLE
Ignore defaultValue on TextField

### DIFF
--- a/src/TextField.js
+++ b/src/TextField.js
@@ -7,9 +7,6 @@ export default createComponent(TextField, ({
   defaultValue,
   ...props
 }) => {
-  if (inputProps.value === '') {
-    inputProps.value = defaultValue || inputProps.value
-  }
   return {
     ...inputProps,
     ...mapError(props)

--- a/src/TextField.js
+++ b/src/TextField.js
@@ -2,13 +2,6 @@ import TextField from 'material-ui/TextField'
 import createComponent from './createComponent'
 import mapError from './mapError'
 
-export default createComponent(TextField, ({
-  input: { ...inputProps },
-  defaultValue,
-  ...props
-}) => {
-  return {
-    ...inputProps,
-    ...mapError(props)
-  }
-})
+export default createComponent(TextField, ({ defaultValue, ...props }) =>
+  mapError(props)
+)

--- a/src/__tests__/TextField.spec.js
+++ b/src/__tests__/TextField.spec.js
@@ -99,7 +99,7 @@ describe('TextField', () => {
     )
   })
 
-  it('should render with defaultValue', () => {
+  it('should ignore defaultValue', () => {
     expect(
       new ReduxFormMaterialUITextField({
         input: {
@@ -115,7 +115,7 @@ describe('TextField', () => {
     ).toEqualJSX(
       <TextField
         name="myText"
-        value="5"
+        value=""
         errorText="FooWarning"
         ref="component"
       />

--- a/src/mapError.js
+++ b/src/mapError.js
@@ -1,7 +1,7 @@
 const mapError = (
   {
     meta: { touched, error, warning } = {},
-    input: { ...inputProps },
+    input,
     ...props
   },
   errorProp = 'errorText'
@@ -9,9 +9,9 @@ const mapError = (
   (touched && (error || warning)
     ? {
         ...props,
-        ...inputProps,
+        ...input,
         [errorProp]: error || warning
       }
-    : { ...inputProps, ...props })
+    : { ...input, ...props })
 
 export default mapError


### PR DESCRIPTION
This reverses #119 and fixes #127.

The `defaultValue` prop to `TextField` doesn't make sense in terms of `redux-form` and controlled inputs. See [the `props.input.value` documentation](http://redux-form.com/6.6.3/docs/api/Field.md/#-input-value-any-) in `redux-form`. If you need a default value, you should provide it to `initialValues`.