### PR TITLE
Search text on Autocomplete now reflects initialValues and values cor…

### DIFF
--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -15,7 +15,7 @@ export default createComponent(AutoComplete, ({
   ...mapError(props),
     dataSourceConfig,
     dataSource,
-    searchText: dataSourceValue ? dataSourceValue && dataSourceValue[dataSourceConfig.text] : value,
+    searchText: dataSourceValue ? dataSourceValue[dataSourceConfig.text] : value,
     onNewRequest: value => {
     onChange(
       typeof value === 'object' && dataSourceConfig

--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -10,7 +10,7 @@ export default createComponent(AutoComplete, ({
 }) => ({
   ...mapError(props),
   dataSourceConfig,
-  searchText: dataSourceConfig ? value[dataSourceConfig.text] : value,
+  searchText: dataSourceConfig && typeof value === 'object' ? value[dataSourceConfig.text] : value,
   onNewRequest: value => {
     onChange(
       typeof value === 'object' && dataSourceConfig

--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -6,12 +6,17 @@ export default createComponent(AutoComplete, ({
   input: { onChange, value },
   onNewRequest,
   dataSourceConfig,
+  dataSource,
   ...props
-}) => ({
+}) => {
+  const dataSourceValue = dataSourceConfig && dataSource.find(data => (
+    data[dataSourceConfig.value] == value));
+  return {
   ...mapError(props),
-  dataSourceConfig,
-  searchText: dataSourceConfig && typeof value === 'object' ? value[dataSourceConfig.text] : value,
-  onNewRequest: value => {
+    dataSourceConfig,
+    dataSource,
+    searchText: dataSourceValue ? dataSourceValue && dataSourceValue[dataSourceConfig.text] : value,
+    onNewRequest: value => {
     onChange(
       typeof value === 'object' && dataSourceConfig
         ? value[dataSourceConfig.value]
@@ -21,9 +26,10 @@ export default createComponent(AutoComplete, ({
       onNewRequest(value)
     }
   },
-  onUpdateInput: value => {
-    if (!dataSourceConfig) {
-      onChange(value)
+    onUpdateInput: value => {
+      if (!dataSourceConfig) {
+        onChange(value)
+      }
     }
-  }
-}))
+  };
+})

--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -27,9 +27,7 @@ export default createComponent(AutoComplete, ({
     }
   },
     onUpdateInput: value => {
-      if (!dataSourceConfig) {
-        onChange(value)
-      }
+      onChange(value)
     }
   };
 })

--- a/src/__tests__/AutoComplete.spec.js
+++ b/src/__tests__/AutoComplete.spec.js
@@ -12,6 +12,11 @@ expect.extend(expectJsx)
 
 describe('AutoComplete', () => {
   const dataSource = ['One', 'Two', 'Three']
+  const dataSourceObject = [
+    { text: 'One', value: 1},
+    { text: 'Two', value: 2},
+    { text: 'Three', value: 3},
+  ]
 
   it('has a display name', () => {
     expect(ReduxFormMaterialUIAutoComplete.displayName).toBe(
@@ -33,6 +38,28 @@ describe('AutoComplete', () => {
       <AutoComplete
         dataSource={dataSource}
         searchText="Foo"
+        onNewRequest={noop}
+        ref="component"
+      />
+    )
+  })
+
+  it('renders an AutoComplete with dataSource objects', () => {
+    expect(
+      new ReduxFormMaterialUIAutoComplete({
+        dataSource: dataSourceObject,
+        dataSourceConfig: { text: 'text', value: 'value' },
+        input: {
+          name: 'myAutoComplete',
+          value: '3',
+          onBlur: noop
+        }
+      }).render()
+    ).toEqualJSX(
+      <AutoComplete
+        dataSource={dataSourceObject}
+        dataSourceConfig={{ text: 'text', value: 'value' }}
+        searchText="Three"
         onNewRequest={noop}
         ref="component"
       />


### PR DESCRIPTION
…rectly.

Autocomplete values are saved as strings in redux-form, so the search text should rely on the value's type (which should almost always be a string) instead of just on whether datasourceConfig is set or not. This should fix #86.