### PR TITLE
Use matching data text as search text

### DIFF
--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -6,11 +6,13 @@ export default createComponent(AutoComplete, ({
   input: { onChange, value },
   onNewRequest,
   dataSourceConfig,
+  dataSource,
   ...props
 }) => ({
   ...mapError(props),
   dataSourceConfig,
-  searchText: dataSourceConfig ? value[dataSourceConfig.text] : value,
+  dataSource,
+  searchText: dataSourceConfig && dataSource ? (dataSource.find((item) => item[dataSourceConfig.value] === value) || {})[dataSourceConfig.text] : value,
   onNewRequest: value => {
     onChange(
       typeof value === 'object' && dataSourceConfig


### PR DESCRIPTION
The current implementation expects an object as `value` when there's a `dataSourceConfig`. But the value is usually just a value, not an object containing the value and the text. So I believe when a value is provided and there's a `dataSourceConfig` the corresponding text should be looked up in the `dataSource`.

Maybe the case where the value is actually an object should be handled too, but I'm not sure it's a valid use case since the current behavior on change is to set only the value in the form data.