### PR TITLE
Allow to define onUpdateInput callback same as on original AutoComplete component

### DIFF
--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -5,6 +5,7 @@ import mapError from './mapError'
 export default createComponent(AutoComplete, ({
   input: { onChange, value },
   onNewRequest,
+  onUpdateInput,
   dataSourceConfig,
   dataSource,
   ...props
@@ -23,9 +24,13 @@ export default createComponent(AutoComplete, ({
       onNewRequest(value)
     }
   },
-  onUpdateInput: value => {
+  onUpdateInput: (value, ...restArgs) => {
     if (!dataSourceConfig) {
       onChange(value)
+    }
+
+    if (onUpdateInput) {
+      onUpdateInput(value, ...restArgs)
     }
   }
 }))

--- a/src/__tests__/AutoComplete.spec.js
+++ b/src/__tests__/AutoComplete.spec.js
@@ -154,6 +154,30 @@ describe('AutoComplete', () => {
     expect(onChange).toHaveBeenCalled().toHaveBeenCalledWith('TheValue')
   })
 
+  it('triggers onUpdateInput callback passed to component', () => {
+    const onUpdateInput = createSpy()
+    const params = { source: 'source' }
+
+    const dom = TestUtils.renderIntoDocument(
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <ReduxFormMaterialUIAutoComplete
+          dataSource={dataSource}
+          input={{ onChange: noop, value: 'Foo' }}
+          onUpdateInput={onUpdateInput}
+        />
+      </MuiThemeProvider>
+    )
+
+    const autocomplete = TestUtils.findRenderedComponentWithType(
+      dom,
+      AutoComplete
+    )
+
+    expect(onUpdateInput).toNotHaveBeenCalled()
+    autocomplete.props.onUpdateInput('TheValue', dataSource, params)
+    expect(onUpdateInput).toHaveBeenCalled().toHaveBeenCalledWith('TheValue', dataSource, params)
+  })
+
   it('provides getRenderedComponent', () => {
     const dom = TestUtils.renderIntoDocument(
       <MuiThemeProvider muiTheme={getMuiTheme()}>


### PR DESCRIPTION
Original `AutoComplete` allows you to define `onUpdateInput` callback which is triggered when input value changes. For example to fetch remote data based on value and update `dataSource` with it. 

This change allows to do same on this `AutoComplete` component. It will also bypass rest of arguments to have same signature as in original component `function(searchText: string, dataSource: array, params: object) => void`