### PR TITLE
Fix onFocus, onBlur events for AutoComplete component

### DIFF
--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -3,13 +3,13 @@ import createComponent from './createComponent'
 import mapError from './mapError'
 
 export default createComponent(AutoComplete, ({
-  input: { onChange, value },
+  input: { onChange, value, ...inputRest },
   onNewRequest,
   dataSourceConfig,
   dataSource,
   ...props
 }) => ({
-  ...mapError(props),
+  ...mapError({ ...props, input: { ...inputRest } }),
   dataSourceConfig,
   dataSource,
   searchText: dataSourceConfig && dataSource ? (dataSource.find((item) => item[dataSourceConfig.value] === value) || {})[dataSourceConfig.text] : value,

--- a/src/__tests__/AutoComplete.spec.js
+++ b/src/__tests__/AutoComplete.spec.js
@@ -12,6 +12,8 @@ expect.extend(expectJsx)
 
 describe('AutoComplete', () => {
   const dataSource = ['One', 'Two', 'Three']
+  const onFocus = () => {}
+  const onBlur = () => {}
 
   it('has a display name', () => {
     expect(ReduxFormMaterialUIAutoComplete.displayName).toBe(
@@ -26,11 +28,15 @@ describe('AutoComplete', () => {
         input: {
           name: 'myAutoComplete',
           value: 'Foo',
-          onBlur: noop
+          onFocus: onFocus,
+          onBlur: onBlur
         }
       }).render()
     ).toEqualJSX(
       <AutoComplete
+        name="myAutoComplete"
+        onFocus={onFocus}
+        onBlur={onBlur}
         dataSource={dataSource}
         searchText="Foo"
         onNewRequest={noop}
@@ -46,7 +52,8 @@ describe('AutoComplete', () => {
         input: {
           name: 'myAutoComplete',
           value: 'Foo',
-          onBlur: noop
+          onFocus: onFocus,
+          onBlur: onBlur
         },
         meta: {
           error: 'FooError'
@@ -54,6 +61,9 @@ describe('AutoComplete', () => {
       }).render()
     ).toEqualJSX(
       <AutoComplete
+        name="myAutoComplete"
+        onBlur={onBlur}
+        onFocus={onFocus}
         dataSource={dataSource}
         searchText="Foo"
         onNewRequest={noop}
@@ -69,7 +79,8 @@ describe('AutoComplete', () => {
         input: {
           name: 'myAutoComplete',
           value: 'Foo',
-          onBlur: noop
+          onFocus: onFocus,
+          onBlur: onBlur
         },
         meta: {
           error: 'FooError',
@@ -78,6 +89,9 @@ describe('AutoComplete', () => {
       }).render()
     ).toEqualJSX(
       <AutoComplete
+        name="myAutoComplete"
+        onBlur={onBlur}
+        onFocus={onFocus}
         dataSource={dataSource}
         searchText="Foo"
         errorText="FooError"
@@ -101,6 +115,7 @@ describe('AutoComplete', () => {
       }).render()
     ).toEqualJSX(
       <AutoComplete
+        name="myAutoComplete"
         dataSource={dataSource}
         searchText="Foo"
         onNewRequest={noop}
@@ -124,6 +139,7 @@ describe('AutoComplete', () => {
       }).render()
     ).toEqualJSX(
       <AutoComplete
+        name="myAutoComplete"
         dataSource={dataSource}
         searchText="Foo"
         errorText="FooWarning"


### PR DESCRIPTION
Pass rest of props from `input` to MaterialUI component, mainly for `onFocus`, `onBlur` callbacks to properly trigger `@@redux-form/FOCUS` `@@redux-form/BLUR` redux actions. 

Without it `touched` meta will never be set and error message will never show. (at least in my use case)