### PR TITLE
Skip validation on blur event when input type button clicked

### DIFF
--- a/src/createComponent.js
+++ b/src/createComponent.js
@@ -26,7 +26,7 @@ export default function createComponent(MaterialUIComponent, mapProps) {
       const propsToMap = {
         ...this.props
       };
-      if (propsToMap && propsToMap.input && propsToMap.input.onBlur) {
+      if (propsToMap.input && propsToMap.input.onBlur) {
         propsToMap.input.onBlur = this.allowClickEventOnInputButton(propsToMap.input.onBlur);
       }
 

--- a/src/createComponent.js
+++ b/src/createComponent.js
@@ -14,8 +14,18 @@ export default function createComponent(MaterialUIComponent, mapProps) {
     }
 
     render() {
+      const propsToMap = {
+        ...this.props,
+        onBlur: (event) => {
+          const { relatedTarget } = event;
+          if (relatedTarget && relatedTarget.getAttribute('type') === 'button') {
+            event.preventDefault();
+          }
+        }
+      }
+
       return createElement(MaterialUIComponent, {
-        ...mapProps(this.props),
+        ...mapProps(propsToMap),
         ref: 'component'
       })
     }

--- a/src/createComponent.js
+++ b/src/createComponent.js
@@ -13,15 +13,21 @@ export default function createComponent(MaterialUIComponent, mapProps) {
       return this.refs.component
     }
 
+    allowClickEventOnInputButton = (onBlur) => (event) => {
+      const { relatedTarget } = event;
+      if (relatedTarget && relatedTarget.getAttribute('type') === 'button') {
+        event.preventDefault();
+      } else if (onBlur) {
+        onBlur(event);
+      }
+    }
+
     render() {
       const propsToMap = {
-        ...this.props,
-        onBlur: (event) => {
-          const { relatedTarget } = event;
-          if (relatedTarget && relatedTarget.getAttribute('type') === 'button') {
-            event.preventDefault();
-          }
-        }
+        ...this.props
+      };
+      if (propsToMap && propsToMap.input && propsToMap.input.onBlur) {
+        propsToMap.input.onBlur = this.allowClickEventOnInputButton(propsToMap.input.onBlur);
       }
 
       return createElement(MaterialUIComponent, {


### PR DESCRIPTION
Solve the need to click two times on a Cancel button (input type button) in order to close a redux form without submitting.

See https://github.com/erikras/redux-form/issues/860 for more details.

Inplementation idea taken from https://github.com/erikras/redux-form/issues/860#issuecomment-294274650