### PR TITLE
Update Peer Dependency for redux-form v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": "15",
-    "redux-form": "6"
+    "redux-form": "6 || 7"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Changed the peerDependency for redux-form from "6" to "6 || 7"

Referenced in Issue #166.