### PR TITLE
Fix jsnext:main field in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,9 +9,6 @@
     },
     "production": {
       "plugins": ["transform-es2015-modules-commonjs"]
-    },
-    "es": {
-      "plugins": ["transform-es2015-modules-commonjs"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An adapter between Redux Form and Material UI components",
   "main": "./lib/index.js",
   "jsnext:main": "./es/index.js",
+  "module": "./es/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/erikras/redux-form-material-ui"


### PR DESCRIPTION
Related literature:

http://2ality.com/2017/04/setting-up-multi-platform-packages.html#jsnextmain-the-precursor-of-module
https://github.com/rollup/rollup/wiki/pkg.module