### PR TITLE
fix AutoComplete component declare in index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types='react'/>
 
 declare module 'redux-form-material-ui' {
-  export class AutoComplete extends React.Component<__MaterialUI.AutoCompleteProps, any> {}
+  export class AutoComplete extends React.Component<__MaterialUI.AutoCompleteProps<string | React.ReactNode>, any> {}
   export class Checkbox extends React.Component<__MaterialUI.Switches.CheckboxProps, any> {}
   export class TimePicker extends React.Component<__MaterialUI.TimePickerProps, any> {}
   export class DatePicker extends React.Component<__MaterialUI.DatePicker.DatePickerProps, any> {}


### PR DESCRIPTION
This PR is to fix issue #196 .
In the index.d.ts file has a code snippet:
```
...
export class AutoComplete extends React.Component<__MaterialUI.AutoCompleteProps, any> {}
```
while `__MaterialUI.AutoCompleteProps<DataItem>` is a Generic type  which need a type parameter .
I found in material-ui AutoComplete component , `DataItem` should be `string or node` , so i fix it to:
```
export class AutoComplete extends React.Component<__MaterialUI.AutoCompleteProps<string | React.ReactNode>, any> {}
```