### PR TITLE
Fixed typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Using [npm](https://www.npmjs.org/):
   $ npm install --save redux-form-material-ui@next
 ```
 
-Using [npm](https://yarnpkg.com):
+Using [yarn](https://yarnpkg.com):
 
 ```bash
   $ yarn add redux-form-material-ui@next


### PR DESCRIPTION
I'm assuming that should say "yarn", not "npm".