### PR TITLE
Fix isStateLess()

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,1 +1,1 @@
-export const isStateLess = Component => !Component.prototype.render
+export const isStateLess = Component => !Component.prototype || !Component.prototype.render


### PR DESCRIPTION
Stateless components like e.g. this one https://github.com/dmtrKovalenko/material-ui-pickers/blob/master/lib/src/_shared/WithUtils.jsx#L5 don't even have a prototype because they are plain functions. So the old `isStateLess()` implementation failed with "Uncaught TypeError: Cannot read property 'render' of undefined."